### PR TITLE
Documentation fix: Use library not gem terminology in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ Special thanks to Andrey Soshchenko @getux.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+The library is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
One word documentation fix to readme to change word `gem` to `library`.

Thanks for putting this project out there as open source :).