### PR TITLE
Update poison to ~> 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule PhoenixGon.Mixfile do
 
   def project do
     [app: :phoenix_gon,
-     version: "0.2.0",
+     version: "0.2.1",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule PhoenixGon.Mixfile do
 
   defp deps do
     [{:ex_doc, ">= 0.0.0", only: :dev},
-     {:poison, "~> 2.0"},
+     {:poison, "~> 3.0"},
      {:phoenix_html, "~> 2.7"},
      {:plug, "~> 1.0"}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -3,4 +3,4 @@
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
   "phoenix_html": {:hex, :phoenix_html, "2.9.3", "1b5a2122cbf743aa242f54dced8a4f1cc778b8bd304f4b4c0043a6250c58e258", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"}}


### PR DESCRIPTION
I had faced dependency issues in Phoenix 1.3.
```
Resolving Hex dependencies...

Failed to use "poison" (version 3.1.0) because
  phoenix (version 1.3.0) requires ~> 2.2 or ~> 3.0
  phoenix_gon (version 0.2.0) requires ~> 2.0
  mix.lock specifies 3.1.0

** (Mix) Hex dependency resolution failed, change the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you
```