### PR TITLE
Bug/6 output sanitization

### DIFF
--- a/lib/phoenix_gon/view.ex
+++ b/lib/phoenix_gon/view.ex
@@ -18,6 +18,10 @@ defmodule PhoenixGon.View do
     end
   end
 
+  @spec escape_assets(Plug.Conn) :: String.t
+  def escape_assets(conn) do
+    escape_javascript(Poison.encode!(assets(conn)))
+  end
 
   @doc false
   @spec script(Plug.Conn) :: List.t
@@ -25,7 +29,7 @@ defmodule PhoenixGon.View do
     """
     var #{namespace(conn)} = (function(window) {
       var phoenixEnv = '#{settings(conn)[:env]}';
-      var phoenixAssets = #{Poison.encode!(assets(conn))};
+      var phoenixAssets = #{escape_assets(conn)};
 
       return {
         getEnv: function() {

--- a/lib/phoenix_gon/view.ex
+++ b/lib/phoenix_gon/view.ex
@@ -29,7 +29,7 @@ defmodule PhoenixGon.View do
     """
     var #{namespace(conn)} = (function(window) {
       var phoenixEnv = '#{settings(conn)[:env]}';
-      var phoenixAssets = #{escape_assets(conn)};
+      var phoenixAssets = JSON.parse("#{escape_assets(conn)}");
 
       return {
         getEnv: function() {

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule PhoenixGon.Mixfile do
 
   def project do
     [app: :phoenix_gon,
-     version: "0.2.1",
+     version: "0.2.2",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -3,4 +3,4 @@
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
   "phoenix_html": {:hex, :phoenix_html, "2.9.3", "1b5a2122cbf743aa242f54dced8a4f1cc778b8bd304f4b4c0043a6250c58e258", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"}}
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"}}

--- a/test/phoenix_gon/view_test.exs
+++ b/test/phoenix_gon/view_test.exs
@@ -20,10 +20,10 @@ defmodule PhoenixGon.ViewTest do
   describe "#escape_assets escapes javascript" do
     test 'text' do
       conn = Pipeline.call(%Conn{}, Pipeline.init([]))
-      conn = put_gon(conn, :malicious, "all your bases</script><script>alert('are belong to us!')</script>")
+      conn = put_gon(conn, :malicious, "all your base</script><script>alert('are belong to us!')</script>")
       
       actual = PhoenixGon.View.escape_assets(conn)
-      expected = "{\\\"malicious\\\":\\\"all your bases<\\/script><script>alert(\\'are belong to us!\\')<\\/script>\\\"}"
+      expected = "{\\\"malicious\\\":\\\"all your base<\\/script><script>alert(\\'are belong to us!\\')<\\/script>\\\"}"
 
       assert expected == actual
     end

--- a/test/phoenix_gon/view_test.exs
+++ b/test/phoenix_gon/view_test.exs
@@ -2,6 +2,7 @@ defmodule PhoenixGon.ViewTest do
   use ExUnit.Case, async: false
 
   import PhoenixGon.TestHelpers
+  import PhoenixGon.Controller
 
   alias PhoenixGon.Pipeline
   alias Plug.Conn
@@ -9,10 +10,22 @@ defmodule PhoenixGon.ViewTest do
   describe "#render_gon_script" do
     test 'text' do
       conn = Pipeline.call(%Conn{}, Pipeline.init([]))
-
+      
       actual = PhoenixGon.View.render_gon_script(conn)
 
       assert {:safe, _} = actual
+    end
+  end
+
+  describe "#escape_assets escapes javascript" do
+    test 'text' do
+      conn = Pipeline.call(%Conn{}, Pipeline.init([]))
+      conn = put_gon(conn, :malicious, "all your bases</script><script>alert('are belong to us!')</script>")
+      
+      actual = PhoenixGon.View.escape_assets(conn)
+      expected = "{\\\"malicious\\\":\\\"all your bases<\\/script><script>alert(\\'are belong to us!\\')<\\/script>\\\"}"
+
+      assert expected == actual
     end
   end
 end


### PR DESCRIPTION
This PR fixes #6 .

I tried a couple of different approaches but this one seemed the simplest. I thought about sanitizing the input when ```put_gon``` is called, but the solution got complicated as the inserted value is not always a string.  

Common practice is to sanitize the output, so that is the approach I took. Phoenix.HTML provides the following helpers functions.

[escape_javascript](https://hexdocs.pm/phoenix_html/Phoenix.HTML.html#escape_javascript/1)
[html_escape](https://hexdocs.pm/phoenix_html/Phoenix.HTML.html#html_escape/1)

Of the two methods, escape_javascript escapes out injected javascript. It can be parsed by JSON.parse.

```
var phoenixAssets = #{Poison.encode!(assets(conn))};
```

was changed to:
```
@spec escape_assets(Plug.Conn) :: String.t
def escape_assets(conn) do
   escape_javascript(Poison.encode!(assets(conn)))
end
```
```
var phoenixAssets = JSON.parse("#{escape_assets(conn)}");
```

Calling:
```
window.Gon.assets()
```

Will work as expected.

---

JSON.parse is supported as of IE9

---  

**Additional Considerations**
Although this fixes XSS in this package, the parsed string available via gon would still need to be sanitized if later used in a ReactJS view. For example:


![image](https://user-images.githubusercontent.com/1287294/35083438-2ad35cf0-fbed-11e7-9923-474a48f8cbaa.png)

I think this is fine since it's outside the scope of the package. If you made an ajax request for a resource that returned the string
```
"all your bases</script><script>alert('are belong to us!')</script>"
```

you would still be expected to sanitize it before you append it to the DOM. Many developers use third party libraries to sanitize HTML. For example lodash

```
_.escape("all your bases</script><script>alert('are belong to us!')</script>");
```
This fix at least mitigates the server returning malicious code within the page.

I'm open to feedback and thoughts! Adding @rmoorman since he opened the original issue.
