### PR TITLE
Fixes #14 JS parsing error in IE11

### DIFF
--- a/lib/phoenix_gon/view.ex
+++ b/lib/phoenix_gon/view.ex
@@ -41,7 +41,7 @@ defmodule PhoenixGon.View do
         isProd: function() {
           return phoenixEnv === 'prod';
         },
-        isCustomEnv(customEnv) {
+        isCustomEnv: function(customEnv) {
           return phoenixEnv === customEnv;
         },
         assets: function() {


### PR DESCRIPTION
* Correct syntax for function definition as a key value

