### PR TITLE
Allow specifying JSON library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ Assets variables methods:
 - `assets()` - Returns all variables setting in config and controllers.
 - `getAsset(key)` - Returns variable by key.
 
+### JSON Library
+
+Per default the `Poison` is used to encode JSON data, however this can be changed via the application configuration:
+
+```elixir
+config :phoenix_gon, :json_library, Jason
+```
+
 ## Contributors
 
 Special thanks to Andrey Soshchenko @getux.

--- a/lib/phoenix_gon/view.ex
+++ b/lib/phoenix_gon/view.ex
@@ -22,7 +22,7 @@ defmodule PhoenixGon.View do
     conn
     |> assets
     |> resolve_assets_case(conn)
-    |> Poison.encode!
+    |> json_library().encode!
     |> escape_javascript
   end
 
@@ -81,4 +81,8 @@ defmodule PhoenixGon.View do
   end
   defp to_camel_case(value),
     do: value
+
+  defp json_library do
+    Application.get_env(:phoenix_gon, :json_library, Poison)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule PhoenixGon.Mixfile do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:poison, "~> 3.0"},
+      {:poison, "~> 3.0", optional: true},
       {:phoenix_html, "~> 2.7"},
       {:plug, "~> 1.0"},
       {:recase, "~> 0.4"}

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,10 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], []},
-  "phoenix_html": {:hex, :phoenix_html, "2.10.5", "4f9df6b0fb7422a9440a73182a566cb9cbe0e3ffe8884ef9337ccf284fc1ef0a", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
-  "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
-  "recase": {:hex, :recase, "0.4.0", "8fb52846f75948156385af2dfdc12f69e5ce27b022a9d1682c70a2fb3ed149c7", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "f050061c87ad39478c942995b5a20c40f2c0bc06525404613b8b0474cb8bd796"},
+  "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
+  "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm", "b24d1d704209b760aeac161255c8031c5160de1a5cb7dd28bb84ef5bda2ba29e"},
+  "phoenix_html": {:hex, :phoenix_html, "2.10.5", "4f9df6b0fb7422a9440a73182a566cb9cbe0e3ffe8884ef9337ccf284fc1ef0a", [:mix], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "4f38ec3263ceb746f0ee7c4955dcdae05497750d795160d87fb45e458981a696"},
+  "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm", "c1c408c57a1e4c88c365b9aff1198c350e22b765dbb97a460e9e6bd9364c6194"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
+  "recase": {:hex, :recase, "0.4.0", "8fb52846f75948156385af2dfdc12f69e5ce27b022a9d1682c70a2fb3ed149c7", [:mix], [], "hexpm", "ecff2accd3f1d58a670d610784c646101260e7a2dec2a02e2b1c088bb5f8df43"},
 }


### PR DESCRIPTION
Since the [`Poison`](https://github.com/devinus/poison) library isn't well maintained anymore many people use the [`Jason`](https://github.com/michalmuskala/jason) library for phoenix.
To keep backwards compatibility the [`Poison`](https://github.com/devinus/poison) library is used by default.